### PR TITLE
checkloginstatus option

### DIFF
--- a/dist/ng-facebook-api.js
+++ b/dist/ng-facebook-api.js
@@ -163,15 +163,17 @@ module.service('FacebookService', function FacebookService($q) {
 	  }
 	  
 	  
-	  var checkLoginStatus = function(){
+	  var checkLoginStatus = function( forcelogin ){
 		  var deferred = $q.defer();
-		  
+		  var forcelogin = (typeof forcelogin == "undefined" || forcelogin == null)?true:forcelogin;
+
 		  FB.getLoginStatus( function (response){
 			  if (response.status === 'connected') {
 				  currentUserAuthResponse = response.authResponse;
 				  deferred.resolve(currentUserAuthResponse);
 			  } else {
-				  deferred.promise = doLogin();
+				  if(forcelogin) deferred.promise = doLogin();
+				  else deferred.reject(null); //Better {response:null,reason:"Not logged in"}
 			  } 
 		  });
 		  


### PR DESCRIPTION
Added an option in `checkLoginStatus()` since some user not necessarily wants a login except just to check if user is logged in to facebook or not. Default param is `true` which would force facebook login